### PR TITLE
update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ out/
 
 # Package Files #
 *.jar
+!libs/*.jar
+!server/*.jar
 *.war
 *.nar
 *.ear


### PR DESCRIPTION
All JAR files were previously ignored by Git, but now JAR files in the libs (e.x. spigot dependency) and server folders (e.x. spigot.jar, other plugins) will be included.