### PR TITLE
Limit Block Clearing Animation to Complete within 15 Ticks

### DIFF
--- a/src/main/java/com/njdge/fastbuilder/profile/BlockClearAnimation.java
+++ b/src/main/java/com/njdge/fastbuilder/profile/BlockClearAnimation.java
@@ -6,12 +6,20 @@ import org.bukkit.block.Block;
 import static com.njdge.fastbuilder.utils.Tasks.runLater;
 
 public class BlockClearAnimation {
+    private static final long DURATION = 15L;
+    
     public static void sequential(PlayerProfile profile) {
         int totalBlocks = profile.getPlacedBlocks().size();
+        if (totalBlocks == 0) return;
+
+        double interval = (double) DURATION / totalBlocks;
         int[] counter = {0};
+        
         profile.getPlacedBlocks().forEach(location -> {
             Block block = location.getBlock();
-            runLater(() -> block.setType(Material.AIR), (long) (totalBlocks * ((double) counter[0]++ / totalBlocks)));
+            long delay = Math.round(counter[0] * interval);
+            runLater(() -> block.setType(Material.AIR), delay);
+            counter[0]++;
         });
     }
 


### PR DESCRIPTION
將方塊清除動畫總時長固定為15刻, 解決了玩家能利用尚未被清除的方塊跳至終點的漏洞
經過測試15刻看起來是最剛好的